### PR TITLE
fix: show stat labels when values are zero in horizontal variant

### DIFF
--- a/packages/canvacord/src/components/LeaderboardBuilder.tsx
+++ b/packages/canvacord/src/components/LeaderboardBuilder.tsx
@@ -374,8 +374,8 @@ export class LeaderboardBuilder extends Builder<LeaderboardProps> {
         </div>
 
         <div className="flex flex-col items-end">
-          {xp && <div className="text-xl font-medium flex">{fixed(xp, this.options.get("abbreviate"))} XP</div>}
-          {level && <div className="text-xl font-medium flex">Level {level}</div>}
+          <div className="text-xl font-medium flex">{fixed(xp, this.options.get("abbreviate"))} XP</div>
+          <div className="text-xl font-medium flex">Level {level}</div>
         </div>
       </div>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed display of zero values in horizontal leaderboard variant. Previously, the conditional checks prevented rendering the stat containers, resulting in `00` being displayed instead of `0 XP` and `Level 0`.

## Motivation and Context
When players had 0 XP or Level 0, the stat divs were not rendered due to falsy conditional checks on the string/number values. Removing these conditionals ensures the full stat display with labels is always shown.


## Screenshots (if appropriate):
BEFORE:
<img width="1002" height="512" alt="image" src="https://github.com/user-attachments/assets/15ed1895-89e8-4b4f-8a61-3905c919fdc1" />

AFTER:
<img width="1002" height="512" alt="image" src="https://github.com/user-attachments/assets/5de51ffb-8e8c-4d9d-8ed1-9178b02c47fb" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
